### PR TITLE
On-screen shape and fill color

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ It works both ways:
 This node has several properties
 
 * `Locale` is used to compute durations in human form. You can tell which locale, the moment library will use
+* `Shape` is used to setup a common status shape for all messages.  This setting can be overruled by the `msg.shape`.
+* `Color` is used to setup a common status fill color for all messages.  This setting can be overruled by the `msg.fill`.
+* `Add update timestamp` is used to add the current timestamp.
 * `Show duration` is used to add a computed duration base on `control start/stop/running` informations sent by `Big Nodes`
 
 You can control the node by sending custom messages:

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ It works both ways:
 This node has several properties
 
 * `Locale` is used to compute durations in human form. You can tell which locale, the moment library will use
-* `Shape` is used to setup a common status shape for all messages.  This setting can be overruled by the `msg.shape`.
-* `Color` is used to setup a common status fill color for all messages.  This setting can be overruled by the `msg.fill`.
+* `Shape` is used to setup a common status shape for all messages.  This setting will overrule the `msg.shape`.
+* `Color` is used to setup a common status fill color for all messages.  This setting will overrule the `msg.fill`.
 * `Add update timestamp` is used to add the current timestamp.
 * `Show duration` is used to add a computed duration base on `control start/stop/running` informations sent by `Big Nodes`
 

--- a/bigstatus/bigstatus.html
+++ b/bigstatus/bigstatus.html
@@ -26,6 +26,26 @@
   </div>  
 
   <div class="form-row">
+      <label for="node-input-shape"><i class="fa fa-pencil"></i> Shape</label>
+      <select type="text" id="node-input-shape" style="width:70%;">
+          <option></option>
+          <option value="dot">Dot</option>
+          <option value="ring">Ring</option>
+      </select>
+  </div>     
+  <div class="form-row">
+      <label for="node-input-fill"><i class="fa fa-paint-brush"></i> Color</label>
+      <select type="text" id="node-input-fill" style="width:70%;">
+          <option></option>
+          <option value="blue">Blue</option>
+          <option value="green">Green</option>
+          <option value="grey">Grey</option>
+          <option value="red">Red</option>
+          <option value="yellow">Yellow</option>
+      </select>
+  </div>   
+    
+  <div class="form-row">
       <label>&nbsp;</label>
       <input type="checkbox" id="node-input-show_date" style="display: inline-block; width: auto; vertical-align: top;">
       <label for="node-input-show_date" style="width: 70%;"><span data-i18n="bigstatus.label.show_date"></span></label>
@@ -55,6 +75,8 @@
         defaults: {               // defines the editable properties of the node
             name: {value:""},     //  along with default values.
             locale: {value:""},
+            shape: {value:""},
+            fill: {value:""},
             show_date: { value: true },
             show_duration: { value: false }
         },

--- a/bigstatus/bigstatus.js
+++ b/bigstatus/bigstatus.js
@@ -42,6 +42,15 @@ module.exports = function(RED) {
     this.on('input', function(msg) {
 
       var status = {};
+      
+      if (config.shape) {
+        status.shape = config.shape;
+      }
+      
+      if (config.fill) {
+        status.fill = config.fill;
+      }      
+      
       if (msg.control) {
         
         switch (msg.control.state) {
@@ -121,5 +130,3 @@ module.exports = function(RED) {
 
   RED.nodes.registerType("bigstatus", bigstatus);
 }
-
-

--- a/bigstatus/bigstatus.js
+++ b/bigstatus/bigstatus.js
@@ -41,15 +41,7 @@ module.exports = function(RED) {
 
     this.on('input', function(msg) {
 
-      var status = {};
-      
-      if (config.shape) {
-        status.shape = config.shape;
-      }
-      
-      if (config.fill) {
-        status.fill = config.fill;
-      }      
+      var status = {};  
       
       if (msg.control) {
         
@@ -75,6 +67,9 @@ module.exports = function(RED) {
             status.text = msg.control.message;
             break;
         }
+        
+        if (config.shape) status.shape = config.shape;
+        if (config.fill)  status.fill  = config.fill;
 
         var duration = moment.duration(moment().diff(msg.control.start, 'seconds')).humanize();
         if (config.show_duration) status.text +=  " (" + duration + ")";
@@ -110,6 +105,10 @@ module.exports = function(RED) {
       } else {    
         if (msg.shape) status.shape = msg.shape;
         if (msg.fill) status.fill = msg.fill;
+        
+        if (config.shape) status.shape = config.shape;
+        if (config.fill)  status.fill  = config.fill;
+        
         msg.payload = status.text = msg.text || msg.payload;
 
         node.send(msg);
@@ -130,3 +129,5 @@ module.exports = function(RED) {
 
   RED.nodes.registerType("bigstatus", bigstatus);
 }
+
+


### PR DESCRIPTION
Dear Jacques (@Jacques44),

Thanks for sharing this contribution!

In my current case, my messages **only** contain the status text (but **no** shape or fill color).  E.g. when I select a new scene in my dashboard ('at home', 'sleeping', 'at work', ...), a '_blue ring_' should be displayed for all these scenes.

To accomplish this, I have added two dropdowns to your properties screen:

![image](https://user-images.githubusercontent.com/14224149/29192585-39516f90-7e22-11e7-9050-ccb29a898c44.png)

To make sure that no existing flows are broken by this enhancement, I used following approach:
- The dropdowns are optional (there is a blanc line in the selection list): no values need to be selected.
- When a message arrives containing a `msg.fill` or a `msg.shape` field, those fields will overrule the dropdown values.

Here is my test flow:
![image](https://user-images.githubusercontent.com/14224149/29192974-c90c667a-7e23-11e7-9802-95558f5a1d20.png)
```
[{"id":"486a63eb.1f6d6c","type":"bigstatus","z":"f711b886.a58148","name":"","locale":"","shape":"","fill":"","show_date":false,"show_duration":false,"x":836.7656173706055,"y":488.6132869720459,"wires":[[]]},{"id":"59b4705e.694bb","type":"inject","z":"f711b886.a58148","name":"Test 1","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"x":422.16396713256836,"y":427.0782096982002,"wires":[["42a7642e.6e6cbc"]]},{"id":"42a7642e.6e6cbc","type":"change","z":"f711b886.a58148","name":"Set error","rules":[{"t":"set","p":"payload","pt":"msg","to":"Major problem","tot":"str"},{"t":"set","p":"fill","pt":"msg","to":"red","tot":"str"},{"t":"set","p":"shape","pt":"msg","to":"ring","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":591.1522674560547,"y":426.99999886751175,"wires":[["486a63eb.1f6d6c"]]},{"id":"2ae62885.343178","type":"inject","z":"f711b886.a58148","name":"Test 2","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"x":422.92958068847656,"y":476.27733689546585,"wires":[["47574abe.925724"]]},{"id":"47574abe.925724","type":"change","z":"f711b886.a58148","name":"Set warning","rules":[{"t":"set","p":"payload","pt":"msg","to":"Small warning","tot":"str"},{"t":"set","p":"fill","pt":"msg","to":"yellow","tot":"str"},{"t":"set","p":"shape","pt":"msg","to":"ring","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":601.9178810119629,"y":476.1991260647774,"wires":[["486a63eb.1f6d6c"]]},{"id":"6465588a.c2f7b8","type":"inject","z":"f711b886.a58148","name":"Test 3","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"x":420.92958068847656,"y":525.2773368954659,"wires":[["636f6191.afdb"]]},{"id":"636f6191.afdb","type":"change","z":"f711b886.a58148","name":"Set normal","rules":[{"t":"set","p":"payload","pt":"msg","to":"Everything fine","tot":"str"},{"t":"set","p":"fill","pt":"msg","to":"green","tot":"str"},{"t":"set","p":"shape","pt":"msg","to":"dot","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":599.9178810119629,"y":525.1991260647774,"wires":[["486a63eb.1f6d6c"]]},{"id":"11921d15.09c7d3","type":"inject","z":"f711b886.a58148","name":"Test 4","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"x":415.765625,"y":624.75,"wires":[["6a18c419.64418c"]]},{"id":"6a18c419.64418c","type":"change","z":"f711b886.a58148","name":"SET ONLY TEXT","rules":[{"t":"set","p":"payload","pt":"msg","to":"Small warning","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":614.7539253234863,"y":624.6717891693115,"wires":[["486a63eb.1f6d6c"]]},{"id":"1b5b797f.27ee67","type":"comment","z":"f711b886.a58148","name":"Legacy tests","info":"","x":417.015625,"y":386.60546875,"wires":[]},{"id":"fac58daa.a0687","type":"comment","z":"f711b886.a58148","name":"New test of message without shape or color","info":"","x":512.765625,"y":585.75,"wires":[]}]
```

Hopefully you like this contribution.
Hope to hear from you soon !

Kind regards,
Bart